### PR TITLE
Add yaml lint actions

### DIFF
--- a/.github/workflows/cue-lint.yaml
+++ b/.github/workflows/cue-lint.yaml
@@ -7,8 +7,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.17.0"
       - name: install cue
         run: go install cuelang.org/go/cmd/cue@latest
       - run: echo $PATH
-      - run: ls -al /home/runner/go
+      - run: ls -al /home/runner/go/bin
       - run: cue vet sample.yaml check.cue

--- a/.github/workflows/cue-lint.yaml
+++ b/.github/workflows/cue-lint.yaml
@@ -1,9 +1,12 @@
 name: yaml lint useing cue
 on: push
-  
-steps:
-  - uses: actions/checkout@v3
-  - uses: actions/setup-go@v3
-  - name: install cue
-    run: go install cuelang.org/go/cmd/cue@latest
-  - run: cue vet sample.yaml check.cue 
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+      - name: install cue
+        run: go install cuelang.org/go/cmd/cue@latest
+      - run: cue vet sample.yaml check.cue

--- a/.github/workflows/cue-lint.yaml
+++ b/.github/workflows/cue-lint.yaml
@@ -9,4 +9,6 @@ jobs:
       - uses: actions/setup-go@v3
       - name: install cue
         run: go install cuelang.org/go/cmd/cue@latest
+      - run: echo $PATH
+      - run: ls -al /home/runner/go
       - run: cue vet sample.yaml check.cue

--- a/.github/workflows/cue-lint.yaml
+++ b/.github/workflows/cue-lint.yaml
@@ -1,0 +1,9 @@
+name: yaml lint useing cue
+on: push
+  
+steps:
+  - uses: actions/checkout@v3
+  - uses: actions/setup-go@v3
+  - name: install cue
+    run: go install cuelang.org/go/cmd/cue@latest
+  - run: cue vet sample.yaml check.cue 

--- a/.github/workflows/cue-lint.yaml
+++ b/.github/workflows/cue-lint.yaml
@@ -11,6 +11,4 @@ jobs:
           go-version: ">=1.17.0"
       - name: install cue
         run: go install cuelang.org/go/cmd/cue@latest
-      - run: echo $PATH
-      - run: ls -al /home/runner/go/bin
       - run: cue vet sample.yaml check.cue

--- a/sample.yaml
+++ b/sample.yaml
@@ -5,7 +5,6 @@ yyyy: &xxxx
 module:
   - name: aaaaa
     <<: *xxxx
-    description: aaaaaa
   - name: bbbbb
     <<: *xxxx
     description: bbbbbb

--- a/sample.yaml
+++ b/sample.yaml
@@ -3,10 +3,9 @@ yyyy: &xxxx
   def: xxxxxxxxx
   task: yyyyyy
 module:
-- name: aaaaa
-  <<: *xxxx
-  description: aaaaaa
-- name: bbbbb
-  <<: *xxxx
-  description: bbbbbb
-
+  - name: aaaaa
+    <<: *xxxx
+    description: aaaaaa
+  - name: bbbbb
+    <<: *xxxx
+    description: bbbbbb

--- a/sample.yaml
+++ b/sample.yaml
@@ -5,6 +5,7 @@ yyyy: &xxxx
 module:
   - name: aaaaa
     <<: *xxxx
+    description: aaaaaa
   - name: bbbbb
     <<: *xxxx
     description: bbbbbb


### PR DESCRIPTION
## やったこと
- GitHub Actions で yaml のバリデーションできるようにした
- `actions/setup-go@v3` は go-version がないと `PATH` に `GOBIN` 等を追加しないようなので、 go-version を追加した

Lintが動くことを確認